### PR TITLE
Use a custom Rust test framework

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 #![no_std]
 #![feature(abi_x86_interrupt)]
+#![cfg_attr(test, no_main)]
+#![feature(custom_test_frameworks)]
+#![test_runner(crate::test_runner)]
+#![reexport_test_harness_main = "test_main"]
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
 #![allow(
     clippy::cast_possible_truncation,
@@ -23,3 +27,62 @@ pub mod gdt;
 pub mod interrupts;
 pub mod limine;
 pub mod serial;
+
+use core::panic::PanicInfo;
+
+pub trait Testable {
+    fn run(&self);
+}
+
+impl<T> Testable for T
+where
+    T: Fn(),
+{
+    fn run(&self) {
+        serial_print!("{}...\t", core::any::type_name::<T>());
+        self();
+        serial_println!("[ok]");
+    }
+}
+
+pub fn test_runner(tests: &[&dyn Testable]) {
+    serial_println!("Running {} tests", tests.len());
+    for test in tests {
+        test.run();
+    }
+}
+
+pub fn test_panic_handler(info: &PanicInfo) -> ! {
+    serial_println!("[failed]\n");
+    serial_println!("Error: {}\n", info);
+    hlt_loop()
+}
+
+/// Entry point for `cargo test`
+#[cfg(test)]
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    test_main();
+    hlt_loop()
+}
+
+#[cfg(test)]
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+pub fn hlt_loop() -> ! {
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
+#[test_case]
+fn trivial_assertion() {
+    use crate::{serial_print, serial_println};
+
+    serial_print!("trivial assertion... ");
+    assert_eq!(1, 1);
+    serial_println!("[ok]");
+}


### PR DESCRIPTION
I'm trying to follow along with <https://os.phil-opp.com/testing/>, but I'm using `limine` instead of the `bootloader` crate, so I have to roll my own a bit.

Pending TODOs:
- Somehow link the test binaries to dedicated ISO files to run in QEMU
  - Use `cargo test --no-run --message-format=json` along with `jq` to fine the produced binaries
  - Move building the ISO with limine into a script. Make sure to tell limine to wait 0 seconds to boot.
- Add QEMU exit after tests run.
- Step back and ensure I actually want to do it this way :smile: I tend to think this is more trouble than its worth. Pure code we can unit test should go into library crates that are unit tested on the host machine, and integration tests will almost certainly need dedicated setup and execution code that isn't helped much by Rust test frameworks.
