### PR TITLE
Implement text buffering and printing to framebuffer

### DIFF
--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -94,6 +94,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "ringbuffer"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6e4fbb37fd18bd949f42583141d650fcdce49dbf759264e4dd3a5df0bc15dc6"
+
+[[package]]
 name = "rust-os"
 version = "0.1.0"
 dependencies = [
@@ -160,6 +166,7 @@ version = "0.1.0"
 dependencies = [
  "bitvec",
  "limine",
+ "ringbuffer",
 ]
 
 [[package]]

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -9,6 +9,8 @@ use alloc::vec::Vec;
 use rust_os::{allocator, boot_info, gdt, interrupts, memory, serial_println};
 use vesa_framebuffer::{ColorChar, TextBuffer, VESAFramebuffer32Bit};
 
+static mut TEXT_BUFFER: TextBuffer = TextBuffer::new();
+
 #[no_mangle]
 extern "C" fn _start() -> ! {
     boot_info::print_limine_boot_info();
@@ -28,15 +30,16 @@ extern "C" fn _start() -> ! {
     };
     serial_println!("framebuffer: {:#?}", framebuffer);
 
-    let mut text_buffer = TextBuffer::new(&mut framebuffer);
-    text_buffer.write_char(ColorChar::white_char(b'H'));
-    text_buffer.write_char(ColorChar::white_char(b'e'));
-    text_buffer.write_char(ColorChar::white_char(b'l'));
-    text_buffer.write_char(ColorChar::white_char(b'l'));
-    text_buffer.write_char(ColorChar::white_char(b'o'));
-    text_buffer.write_char(ColorChar::white_char(b'!'));
+    unsafe {
+        TEXT_BUFFER.write_char(ColorChar::white_char(b'H'));
+        TEXT_BUFFER.write_char(ColorChar::white_char(b'e'));
+        TEXT_BUFFER.write_char(ColorChar::white_char(b'l'));
+        TEXT_BUFFER.write_char(ColorChar::white_char(b'l'));
+        TEXT_BUFFER.write_char(ColorChar::white_char(b'o'));
+        TEXT_BUFFER.write_char(ColorChar::white_char(b'!'));
 
-    text_buffer.flush();
+        TEXT_BUFFER.flush(&mut framebuffer);
+    };
 
     init();
 

--- a/vesa_framebuffer/Cargo.lock
+++ b/vesa_framebuffer/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "ringbuffer"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6e4fbb37fd18bd949f42583141d650fcdce49dbf759264e4dd3a5df0bc15dc6"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +50,7 @@ version = "0.1.0"
 dependencies = [
  "bitvec",
  "limine",
+ "ringbuffer",
 ]
 
 [[package]]

--- a/vesa_framebuffer/Cargo.toml
+++ b/vesa_framebuffer/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 # N.B. Make sure limine version matches kernel!
 limine = "0.1.10"
+ringbuffer = "0.13"
 
 [dependencies.bitvec]
 version = "1"

--- a/vesa_framebuffer/src/text_buffer.rs
+++ b/vesa_framebuffer/src/text_buffer.rs
@@ -1,11 +1,30 @@
 use bitvec::prelude::AsBits;
+use ringbuffer::{ConstGenericRingBuffer, RingBufferExt, RingBufferWrite};
 
-use crate::font::{FONT_START_CHAR, FONT_WIDTH_PIXELS, OPENGL_FONT};
-use crate::framebuffer::{VESAFramebuffer32Bit, ARGB32BIT_BLACK, ARGB32BIT_WHITE};
+use crate::font::{FONT_HEIGHT_PIXELS, FONT_START_CHAR, FONT_WIDTH_PIXELS, OPENGL_FONT};
+use crate::framebuffer::{ARGB32Bit, VESAFramebuffer32Bit, ARGB32BIT_BLACK, ARGB32BIT_WHITE};
+
+/// ASCII character along with a color.
+#[derive(Debug, Copy, Clone)]
+pub struct ColorChar {
+    char_byte: u8,
+    color: ARGB32Bit,
+}
+
+impl ColorChar {
+    pub fn new(char_byte: u8, color: ARGB32Bit) -> Self {
+        ColorChar { char_byte, color }
+    }
+
+    pub fn white_char(char_byte: u8) -> Self {
+        ColorChar::new(char_byte, ARGB32BIT_WHITE)
+    }
+}
 
 /// A cursor-based text buffer that can print text to a framebuffer.
 pub struct TextBuffer<'a> {
     framebuffer: &'a mut VESAFramebuffer32Bit,
+    text_buffer: TextLineBuffer,
 }
 
 impl<'a> TextBuffer<'a> {
@@ -13,28 +32,109 @@ impl<'a> TextBuffer<'a> {
     pub fn new(framebuffer: &'a mut VESAFramebuffer32Bit) -> TextBuffer<'a> {
         TextBuffer {
             framebuffer,
+            text_buffer: TextLineBuffer::new(),
         }
     }
 
-    pub fn write_char(&mut self, x: usize, y: usize, byte: u8) {
-        let index: usize = match byte.checked_sub(FONT_START_CHAR) {
-            Some(index) => index as usize,
-            None => return,
+    /// Writes a character to the internal `TextLineBuffer`, but doesn't flush
+    /// the text to the framebuffer. You must call `flush` to draw the text to
+    /// the framebuffer.
+    pub fn write_char(&mut self, c: ColorChar) {
+        self.text_buffer.write_char(c);
+    }
+
+    /// Clear the framebuffer and then draw all the text that fits in the
+    /// framebuffer.
+    pub fn flush(&mut self) {
+        flush(self.framebuffer, &mut self.text_buffer);
+    }
+}
+
+// This function only exists to make the borrow checker happy.
+fn flush(framebuffer: &mut VESAFramebuffer32Bit, text_buffer: &mut TextLineBuffer) {
+    framebuffer.clear();
+
+    // Start at the last line of the text buffer and draw lines until we run
+    // out of space in the framebuffer or we run out of lines in the text
+    // buffer.
+    let mut pixel_y: usize = framebuffer.height_pixels();
+    let mut lines_from_bottom: isize = 0;
+
+    while let Some(line) = text_buffer.buffer.get(lines_from_bottom) {
+        // N.B. We copy the line here because we can't iterate over the line
+        // while we are mutating ourselves due to the borrow checker. If we
+        // want to get rid of this copy, we can create a new function that
+        // takes the framebuffer and the text buffer as separate arguments.
+        let line = *line;
+        lines_from_bottom += 1;
+
+        // Find y coordinate for line. The +1 is for spacing between lines
+        pixel_y = match pixel_y.checked_sub(FONT_HEIGHT_PIXELS + 1) {
+            Some(y) => y,
+            None => break,
         };
 
-        let char_bytes = match OPENGL_FONT.get(index) {
-            Some(bytes) => bytes,
-            None => return,
-        };
-        let bitmap = char_bytes.as_bits::<bitvec::order::Msb0>();
+        let mut x = 1; // A bit of space from left edge of screen
+        for c in line.iter() {
+            if x + FONT_WIDTH_PIXELS > framebuffer.width_pixels() {
+                break;
+            }
+            draw_char(framebuffer, x, pixel_y, *c);
+            x += FONT_WIDTH_PIXELS + 1; // +1 for padding between characters
+        }
+    }
+}
 
-        self.framebuffer.draw_bitmap(
-            x,
-            y,
-            bitmap,
-            FONT_WIDTH_PIXELS,
-            ARGB32BIT_WHITE,
-            ARGB32BIT_BLACK,
-        );
+fn draw_char(framebuffer: &mut VESAFramebuffer32Bit, x: usize, y: usize, c: ColorChar) {
+    let index: usize = match c.char_byte.checked_sub(FONT_START_CHAR) {
+        Some(index) => index as usize,
+        None => return,
+    };
+
+    let char_bytes = match OPENGL_FONT.get(index) {
+        Some(bytes) => bytes,
+        None => return,
+    };
+    let bitmap = char_bytes.as_bits::<bitvec::order::Msb0>();
+
+    framebuffer.draw_bitmap(x, y, bitmap, FONT_WIDTH_PIXELS, c.color, ARGB32BIT_BLACK);
+}
+
+/// Buffer that holds `N` lines of colored text that are `W` characters wide.
+struct TextLineBuffer<const N: usize = 50, const W: usize = 100> {
+    /// Ring buffer that holds the text lines.
+    buffer: ConstGenericRingBuffer<[ColorChar; W], N>,
+
+    /// Cursor into the current line of text.
+    cursor: usize,
+}
+
+impl<const N: usize, const W: usize> TextLineBuffer<N, W> {
+    fn new() -> Self {
+        let mut buffer = Self {
+            buffer: ConstGenericRingBuffer::new(),
+            cursor: 0,
+        };
+        buffer.new_line();
+        buffer
+    }
+
+    fn new_line(&mut self) {
+        self.buffer.push([ColorChar::new(0x00, ARGB32BIT_WHITE); W]);
+        self.cursor = 0;
+    }
+
+    fn write_char(&mut self, c: ColorChar) {
+        if self.cursor == W || c.char_byte == b'\n' {
+            self.new_line();
+        }
+
+        let current_line = self
+            .buffer
+            .back_mut()
+            .expect("TextLineBuffer invariant failed: must always have a current line");
+
+        current_line[self.cursor] = c;
+        self.cursor += 1;
     }
 }

--- a/vesa_framebuffer/src/text_buffer.rs
+++ b/vesa_framebuffer/src/text_buffer.rs
@@ -1,5 +1,5 @@
 use bitvec::prelude::AsBits;
-use ringbuffer::{ConstGenericRingBuffer, RingBufferExt, RingBufferWrite};
+use ringbuffer::{ConstGenericRingBuffer, RingBuffer, RingBufferExt, RingBufferWrite};
 
 use crate::font::{FONT_HEIGHT_PIXELS, FONT_START_CHAR, FONT_WIDTH_PIXELS, OPENGL_FONT};
 use crate::framebuffer::{ARGB32Bit, VESAFramebuffer32Bit, ARGB32BIT_BLACK, ARGB32BIT_WHITE};
@@ -22,65 +22,90 @@ impl ColorChar {
 }
 
 /// A cursor-based text buffer that can print text to a framebuffer.
-pub struct TextBuffer<'a> {
-    framebuffer: &'a mut VESAFramebuffer32Bit,
-    text_buffer: TextLineBuffer,
+pub struct TextBuffer<const N: usize = 50, const W: usize = 100> {
+    /// Ring buffer that holds the text lines.
+    buffer: ConstGenericRingBuffer<[ColorChar; W], N>,
+
+    /// Cursor into the current line of text.
+    cursor: usize,
 }
 
-impl<'a> TextBuffer<'a> {
-    /// Creates a new text buffer.
-    pub fn new(framebuffer: &'a mut VESAFramebuffer32Bit) -> TextBuffer<'a> {
-        TextBuffer {
-            framebuffer,
-            text_buffer: TextLineBuffer::new(),
+impl<const N: usize, const W: usize> TextBuffer<N, W> {
+    pub const fn new() -> Self {
+        Self {
+            buffer: ConstGenericRingBuffer::new(),
+            cursor: 0,
         }
+    }
+
+    fn new_line(&mut self) {
+        self.buffer.push([ColorChar::new(0x00, ARGB32BIT_WHITE); W]);
+        self.cursor = 0;
     }
 
     /// Writes a character to the internal `TextLineBuffer`, but doesn't flush
     /// the text to the framebuffer. You must call `flush` to draw the text to
     /// the framebuffer.
     pub fn write_char(&mut self, c: ColorChar) {
-        self.text_buffer.write_char(c);
+        if self.cursor == W || c.char_byte == b'\n' {
+            self.new_line();
+        }
+
+        // Get the current line, ensuring one exists.
+        let current_line = match self.buffer.back_mut() {
+            Some(line) => line,
+            None => {
+                self.new_line();
+                self.buffer.back_mut().unwrap()
+            }
+        };
+
+        current_line[self.cursor] = c;
+        self.cursor += 1;
     }
 
     /// Clear the framebuffer and then draw all the text that fits in the
     /// framebuffer.
-    pub fn flush(&mut self) {
-        flush(self.framebuffer, &mut self.text_buffer);
-    }
-}
+    pub fn flush(&mut self, framebuffer: &mut VESAFramebuffer32Bit) {
+        framebuffer.clear();
 
-// This function only exists to make the borrow checker happy.
-fn flush(framebuffer: &mut VESAFramebuffer32Bit, text_buffer: &mut TextLineBuffer) {
-    framebuffer.clear();
+        // Start at the last line of the text buffer and draw lines until we run
+        // out of space in the framebuffer or we run out of lines in the text
+        // buffer.
+        let mut pixel_y: usize = framebuffer.height_pixels();
+        let mut lines_from_bottom: isize = 0;
 
-    // Start at the last line of the text buffer and draw lines until we run
-    // out of space in the framebuffer or we run out of lines in the text
-    // buffer.
-    let mut pixel_y: usize = framebuffer.height_pixels();
-    let mut lines_from_bottom: isize = 0;
-
-    while let Some(line) = text_buffer.buffer.get(lines_from_bottom) {
-        // N.B. We copy the line here because we can't iterate over the line
-        // while we are mutating ourselves due to the borrow checker. If we
-        // want to get rid of this copy, we can create a new function that
-        // takes the framebuffer and the text buffer as separate arguments.
-        let line = *line;
-        lines_from_bottom += 1;
-
-        // Find y coordinate for line. The +1 is for spacing between lines
-        pixel_y = match pixel_y.checked_sub(FONT_HEIGHT_PIXELS + 1) {
-            Some(y) => y,
-            None => break,
-        };
-
-        let mut x = 1; // A bit of space from left edge of screen
-        for c in line.iter() {
-            if x + FONT_WIDTH_PIXELS > framebuffer.width_pixels() {
+        loop {
+            if lines_from_bottom == self.buffer.len() as isize {
                 break;
             }
-            draw_char(framebuffer, x, pixel_y, *c);
-            x += FONT_WIDTH_PIXELS + 1; // +1 for padding between characters
+
+            let line = match self.buffer.get(lines_from_bottom) {
+                Some(line) => line,
+                None => break,
+            };
+            lines_from_bottom += 1;
+
+            // N.B. We copy the line here because we can't iterate over the line
+            // while we are mutating ourselves due to the borrow checker. If we
+            // want to get rid of this copy, we can create a new function that
+            // takes the framebuffer and the text buffer as separate arguments.
+            let line = *line;
+
+            // Find y coordinate for line. The +1 is for spacing between lines
+            pixel_y = match pixel_y.checked_sub(FONT_HEIGHT_PIXELS + 1) {
+                Some(y) => y,
+                None => break,
+            };
+
+            let mut x = 1; // A bit of space from left edge of screen
+            for c in line.iter() {
+                if x + FONT_WIDTH_PIXELS > framebuffer.width_pixels() {
+                    break;
+                }
+                draw_char(framebuffer, x, pixel_y, *c);
+                x += FONT_WIDTH_PIXELS + 1; // +1 for padding between characters
+            }
         }
     }
 }
@@ -98,43 +123,4 @@ fn draw_char(framebuffer: &mut VESAFramebuffer32Bit, x: usize, y: usize, c: Colo
     let bitmap = char_bytes.as_bits::<bitvec::order::Msb0>();
 
     framebuffer.draw_bitmap(x, y, bitmap, FONT_WIDTH_PIXELS, c.color, ARGB32BIT_BLACK);
-}
-
-/// Buffer that holds `N` lines of colored text that are `W` characters wide.
-struct TextLineBuffer<const N: usize = 50, const W: usize = 100> {
-    /// Ring buffer that holds the text lines.
-    buffer: ConstGenericRingBuffer<[ColorChar; W], N>,
-
-    /// Cursor into the current line of text.
-    cursor: usize,
-}
-
-impl<const N: usize, const W: usize> TextLineBuffer<N, W> {
-    fn new() -> Self {
-        let mut buffer = Self {
-            buffer: ConstGenericRingBuffer::new(),
-            cursor: 0,
-        };
-        buffer.new_line();
-        buffer
-    }
-
-    fn new_line(&mut self) {
-        self.buffer.push([ColorChar::new(0x00, ARGB32BIT_WHITE); W]);
-        self.cursor = 0;
-    }
-
-    fn write_char(&mut self, c: ColorChar) {
-        if self.cursor == W || c.char_byte == b'\n' {
-            self.new_line();
-        }
-
-        let current_line = self
-            .buffer
-            .back_mut()
-            .expect("TextLineBuffer invariant failed: must always have a current line");
-
-        current_line[self.cursor] = c;
-        self.cursor += 1;
-    }
 }


### PR DESCRIPTION
Adds a statically-allocated text buffer that stores text and flushes to the framebuffer. We just redraw the whole framebuffer during a flush because it is quick and easy to reason about.